### PR TITLE
Update to version 0.0.48

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
   <li>get_config</li>
   <li>get_facts</li>
   <li>get_vlans</li>
+  <li>is_alive</li>
+  <li>get_interfaces</li>
+  <li>get_lldp_neighbors</li>
+  <li>get_lldp_neighbors_detail</li>
   <li>get_equipment_ont_status_xpon</li>
   <li>get_equipment_ont_interfaces</li>
   <li>get_equipment_ont_status_pon</li>
@@ -28,7 +32,6 @@
   <li>get_equipment_temperature</li>
   <li>cli</li>
   <li>get_ntp_servers</li>
-  <li>get_interfaces</li>
   <li>send_single_command</li>
 </ul>
 <p>Each function will always return the output as dict data-type </p>

--- a/napalm_nokia_olt/napalm_nokia_olt/__init__.py
+++ b/napalm_nokia_olt/napalm_nokia_olt/__init__.py
@@ -4,4 +4,4 @@
 from napalm_nokia_olt.nokia_olt import NokiaOltDriver
 __all__ = ("NokiaOltDriver",)
 
-__version__ = "0.0.47"
+__version__ = "0.0.48"

--- a/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
+++ b/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
@@ -70,12 +70,6 @@ class NokiaOltDriver(NetworkDriver):
             command += " xml"
         output = self.device.send_command(command, expect_string=r"#$")
         return output
-            # elif "info" in command:
-            #     output = self.device.send_command(command, expect_string=r"#$")
-            #     return output
-            # else:
-            #     output = self.device.send_command(command, expect_string=r"(#|$)")
-            #     return output
 
     def open(self):
         """Open an SSH tunnel connection to the device."""
@@ -90,8 +84,6 @@ class NokiaOltDriver(NetworkDriver):
             **self.netmiko_optional_args,
         )
         self._prep_session()
-        # ensure in enable mode
-        # self.device.enable()
 
     def close(self):
         """Close the connection to the device."""
@@ -583,13 +575,13 @@ class NokiaOltDriver(NetworkDriver):
             return f"No available ** {command} ** data from the {self.hostname}"
 
     def get_vlan_name(self):
-            """Returns VLANs info"""
-            command = "show vlan name"
-            data = self._send_command(command, xml_format=True)
-            if data:
-                return self.convert_xml_to_dict(data)
-            else:
-                return f"No available ** {command} ** data from the {self.hostname}"
+        """Returns VLANs info"""
+        command = "show vlan name"
+        data = self._send_command(command, xml_format=True)
+        if data:
+            return self.convert_xml_to_dict(data)
+        else:
+            return f"No available ** {command} ** data from the {self.hostname}"
 
     def get_vlan_bridge_port_fdb(self):
         """Returns VLANs info details"""

--- a/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
+++ b/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
@@ -219,7 +219,7 @@ class NokiaOltDriver(NetworkDriver):
         os_command = "show software-mngt version ansi"
         uptime_command = "show core1-uptime"
         sn_command = "show equipment shelf 1/1 detail"
-        port_command = "show interface port"
+        port_command = "show equipment ont interface"
 
         hostname_output = self._send_command(hostname_command, xml_format=True)
         os_output = self._send_command(os_command, xml_format=True)
@@ -283,11 +283,8 @@ class NokiaOltDriver(NetworkDriver):
         # get interface_list
         for elem in port_xml_tree.findall(".//instance"):
             dummy_data = self._convert_xml_elem_to_dict(elem=elem)
-            if "port" in dummy_data:
-                port_raw = dummy_data["port"]
-                if "vlan" in port_raw:
-                    continue
-                port_list.append(port_raw)
+            if "ont-idx" in dummy_data:
+                port_list.append(dummy_data["ont-idx"])
         port_list.sort()
         facts["interface_list"] = port_list
         return facts

--- a/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
+++ b/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
@@ -285,7 +285,7 @@ class NokiaOltDriver(NetworkDriver):
             dummy_data = self._convert_xml_elem_to_dict(elem=elem)
             if "ont-idx" in dummy_data:
                 port_list.append(dummy_data["ont-idx"])
-        port_list.sort()
+        port_list.sort(key=lambda p: list(map(int, p.split("/"))))
         facts["interface_list"] = port_list
         return facts
 

--- a/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
+++ b/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
@@ -66,12 +66,10 @@ class NokiaOltDriver(NetworkDriver):
 
     def _send_command(self, command, xml_format=False):
         """Send command to device"""
-        # if true:
-            # append xml to the end of the command
         if xml_format:
-            command = command + " " + "xml"
-            output = self.device.send_command(command, expect_string=r"#$")
-            return output
+            command += " xml"
+        output = self.device.send_command(command, expect_string=r"#$")
+        return output
             # elif "info" in command:
             #     output = self.device.send_command(command, expect_string=r"#$")
             #     return output
@@ -274,6 +272,9 @@ class NokiaOltDriver(NetworkDriver):
             if "serial-no" in dummy_data:
                 serial_number = dummy_data["serial-no"]
                 facts["serial_number"] = serial_number
+            if "variant" in dummy_data:
+                variant = dummy_data["variant"]
+                facts["model"] += f" ({variant})"
 
         # get uptime
         for line in uptime_output.splitlines():

--- a/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
+++ b/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
@@ -307,7 +307,7 @@ class NokiaOltDriver(NetworkDriver):
         # create default dict and get vlan_id and name
         for elem in output_xml_tree.findall(".//instance"):
             dummy_data = self._convert_xml_elem_to_dict(elem=elem)
-            primary_key = dummy_data["id"]
+            primary_key = int(dummy_data["id"])
             if primary_key not in vlans:
                 vlans[primary_key] = {}
                 vlans[primary_key]["name"] = dummy_data["name"]
@@ -316,7 +316,7 @@ class NokiaOltDriver(NetworkDriver):
         # get tagged/untagged ports
         for elem in tag_xml_tree.findall(".//instance"):
             dummy_data = self._convert_xml_elem_to_dict(elem=elem)
-            vlan_id = dummy_data["vlan-id"]
+            vlan_id = int(dummy_data["vlan-id"])
             port_raw = dummy_data["vlan-port"]
             port = ":".join(
                 port_raw.replace("vlan-port", "uni").split(":")[0:2]

--- a/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
+++ b/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
@@ -318,9 +318,7 @@ class NokiaOltDriver(NetworkDriver):
             dummy_data = self._convert_xml_elem_to_dict(elem=elem)
             vlan_id = int(dummy_data["vlan-id"])
             port_raw = dummy_data["vlan-port"]
-            port = ":".join(
-                port_raw.replace("vlan-port", "uni").split(":")[0:2]
-            )
+            port = port_raw.split(":")[1]
             if (
                 "single-tagged" in dummy_data["transmit-mode"]
                 or "untagged" in dummy_data["transmit-mode"]

--- a/napalm_nokia_olt/setup.py
+++ b/napalm_nokia_olt/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="napalm_nokia_olt",
-    version="0.0.47",
+    version="0.0.48",
     author="Dave Macias",
     author_email = "davama@gmail.com",
     description=("Network Automation and Programmability Abstraction "

--- a/napalm_nokia_olt/setup.py
+++ b/napalm_nokia_olt/setup.py
@@ -26,5 +26,5 @@ setuptools.setup(
         "License :: OSI Approved :: BSD License",
     ],
     include_package_data=True,
-    install_requires=('napalm>=3','xmltodict', 'sshFRIEND'),
+    install_requires=('napalm>=3','xmltodict'),
 )   


### PR DESCRIPTION
Bugfixes:
- Fix _send_command for non-xml data
- Fix order of interfaces in get_facts
- Return correct data for get_interfaces method (match format of other NAPALM drivers)
- Change vlan_id type to int to comply with other drivers

Improvements:
- Accelerate get_facts by using different port command
- Unify interface names in get_vlans output
- Remove dependency sshFRIEND

New features:
- Add new method get_lldp_neighbors
- Add new method get_lldp_neighbors_detail