### PR TITLE
Update to version 0.0.49

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <li>get_vlan_fdb_board</li>
   <li>get_ethernet_ont_operational_data</li>
   <li>get_equipment_ont_sw_version</li>
-  <li>get_software_mngt_version_etsi</li>
+  <li>get_software_mgmt_version_etsi</li>
   <li>get_equipment_transceiver_inventor</li>
   <li>get_equipment_diagnostics_sfp</li>
   <li>get_vlan_name</li>

--- a/napalm_nokia_olt/napalm_nokia_olt/__init__.py
+++ b/napalm_nokia_olt/napalm_nokia_olt/__init__.py
@@ -4,4 +4,4 @@
 from napalm_nokia_olt.nokia_olt import NokiaOltDriver
 __all__ = ("NokiaOltDriver",)
 
-__version__ = "0.0.48"
+__version__ = "0.0.49"

--- a/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
+++ b/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
@@ -565,7 +565,7 @@ class NokiaOltDriver(NetworkDriver):
         else:
             return f"No available ** {command} ** data from the {self.hostname}"
 
-    def get_software_mngt_version_etsi(self):
+    def get_software_mgmt_version_etsi(self):
         """Returns software version for management """
         command = "show software-mngt version etsi"
         data = self._send_command(command, xml_format=True)

--- a/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
+++ b/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
@@ -127,8 +127,8 @@ class NokiaOltDriver(NetworkDriver):
                     software = f"{line[-2]}"
                     return {'ISAM': software}
 
-    def convert_xml_to_dict(self, xml_data):
-        """Convert xml data to dict format"""
+    def convert_xml_to_list(self, xml_data):
+        """Convert xml data to list format"""
         if xml_data:
             root = """"""
             for line in xml_data.splitlines():
@@ -159,6 +159,18 @@ class NokiaOltDriver(NetworkDriver):
             key_value = e.text
             data[key_name] = key_value
         return data
+
+    def _convert_list_to_dict(self, data, key):
+        """
+        Convert list of data to dict using given key
+        """
+        data_dict = {}
+        for record in data:
+            try:
+                data_dict[record[key]] = record
+            except KeyError:
+                pass
+        return data_dict
 
     def cli(self, commands):
         """A generic function that allows the client to send any command to the remote device"""
@@ -348,11 +360,11 @@ class NokiaOltDriver(NetworkDriver):
               <info name="hostname" short-name="hostname" type="Gpon::HostName">undefined</info>
             </instance>
         """
-
         command = "show equipment ont status x-pon"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list = self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "ont")
         else:
             return f"No available data from the {self.hostname}"
 
@@ -377,11 +389,11 @@ class NokiaOltDriver(NetworkDriver):
             <info name="actual-us-rate" short-name="actual-us-rate" type="Gpon::ActualUsRate">1.25g</info>
           </instance>
         """
-
         command = "show equipment ont interface"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list = self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "ont-idx")
         else:
             return f"No available data from the {self.hostname}"
 
@@ -405,11 +417,11 @@ class NokiaOltDriver(NetworkDriver):
             <info name="actual-us-rate" short-name="actual-us-rate" type="Gpon::ActualUsRate">1.25g</info>
           </instance>
         """
-
         command = "show equipment ont status pon"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list =  self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "ont")
         else:
             return f"No available data from the {self.hostname}"
 
@@ -430,11 +442,11 @@ class NokiaOltDriver(NetworkDriver):
             <info name="transmit-mode" short-name="transmit-mode" type="Vlan::PortUntagStatus">untagged</info>
           </instance>
         """
-
         command = "show vlan residential-bridge extensive"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list = self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "vlan-port")
         else:
             return f"No available data from the {self.hostname}"
 
@@ -457,7 +469,8 @@ class NokiaOltDriver(NetworkDriver):
         command = "show pon unprovision-onu"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list = self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "gpon-index")
         else:
             return f"No available data from the {self.hostname}"
 
@@ -466,7 +479,8 @@ class NokiaOltDriver(NetworkDriver):
         command = "show equipment slot"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list = self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "slot")
         else:
             return f"No available ** {command} ** data from the {self.hostname}"
 
@@ -475,7 +489,8 @@ class NokiaOltDriver(NetworkDriver):
         command = "show equipment slot detail"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list = self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "slot")
         else:
             return f"No available ** {command} ** data from the {self.hostname}"
 
@@ -484,7 +499,8 @@ class NokiaOltDriver(NetworkDriver):
         command = "show equipment ont slot"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list = self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "ont-slot-idx")
         else:
             return f"No available ** {command} ** data from the {self.hostname}"
 
@@ -493,7 +509,8 @@ class NokiaOltDriver(NetworkDriver):
         command = "show equipment ont optics"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list = self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "ont-idx")
         else:
             return f"No available ** {command} ** data from the {self.hostname}"
 
@@ -502,7 +519,8 @@ class NokiaOltDriver(NetworkDriver):
         command = "show pon optics"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list = self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "pon-idx")
         else:
             return f"No available ** {command} ** data from the {self.hostname}"
 
@@ -512,7 +530,8 @@ class NokiaOltDriver(NetworkDriver):
         data = self._send_command(command, xml_format=True)
         if data:
             if data:
-                return self.convert_xml_to_dict(data)
+                data_list = self.convert_xml_to_list(data)
+                return self._convert_list_to_dict(data_list, "ont-idx")
         else:
             return f"No available ** {command} ** data from the {self.hostname}"
 
@@ -521,7 +540,8 @@ class NokiaOltDriver(NetworkDriver):
         command = "show vlan fdb-board"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list =  self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "mac")
         else:
             return f"No available ** {command} ** data from the {self.hostname}"
 
@@ -530,7 +550,8 @@ class NokiaOltDriver(NetworkDriver):
         command = "show ethernet ont operational-data"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list = self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "uni-idx")
         else:
             return f"No available ** {command} ** data from the {self.hostname}"
 
@@ -539,7 +560,8 @@ class NokiaOltDriver(NetworkDriver):
         command = "show equipment ont sw-version"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list = self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "sw-ver-id")
         else:
             return f"No available ** {command} ** data from the {self.hostname}"
 
@@ -557,7 +579,8 @@ class NokiaOltDriver(NetworkDriver):
         command = "show equipment transceiver-inventor"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list = self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "index")
         else:
             return f"No available ** {command} ** data from the {self.hostname}"
 
@@ -566,7 +589,8 @@ class NokiaOltDriver(NetworkDriver):
         command = "show equipment diagnostics sfp"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list =  self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "position")
         else:
             return f"No available ** {command} ** data from the {self.hostname}"
 
@@ -575,7 +599,8 @@ class NokiaOltDriver(NetworkDriver):
         command = "show vlan name"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list = self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "id")
         else:
             return f"No available ** {command} ** data from the {self.hostname}"
 
@@ -583,9 +608,8 @@ class NokiaOltDriver(NetworkDriver):
         """Returns VLANs info details"""
         command = "show vlan bridge-port-fdb"
         data = self._send_command(command, xml_format=True)
-
         if data:
-            tmp_data = self.convert_xml_to_dict(data)
+            tmp_data = self.convert_xml_to_list(data)
             loaded_data = tmp_data
             new_dict = {}
 
@@ -612,7 +636,8 @@ class NokiaOltDriver(NetworkDriver):
         command = "show equipment temperature"
         data = self._send_command(command, xml_format=True)
         if data:
-            return self.convert_xml_to_dict(data)
+            data_list = self.convert_xml_to_list(data)
+            return self._convert_list_to_dict(data_list, "sensor-id")
         else:
             return f"No available ** {command} ** data from the {self.hostname}"
 
@@ -620,7 +645,7 @@ class NokiaOltDriver(NetworkDriver):
         """Returns IPV6 NTP servers."""
         command = "show sntp server-tablev6 "
         data = self._send_command(command, xml_format=True)
-        data = self.convert_xml_to_dict(data)
+        data = self.convert_xml_to_list(data)
 
         ntp_servers = defaultdict(list)
         for sub in data:

--- a/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
+++ b/napalm_nokia_olt/napalm_nokia_olt/nokia_olt.py
@@ -24,14 +24,7 @@ REMOTE_SYS_EN_CAP_REGEX = r"^Enabled Caps[\s:]+(.+)$"
 class NokiaOltDriver(NetworkDriver):
     """NAPALM Nokia OLT Handler."""
 
-    def __init__(
-            self,
-            hostname,
-            username,
-            password,
-            timeout=60,
-            optional_args=None
-    ):
+    def __init__(self, hostname, username, password, timeout=60, optional_args=None):
         if optional_args is None:
             optional_args = {}
         self.transport = optional_args.get("transport", "ssh")
@@ -111,9 +104,7 @@ class NokiaOltDriver(NetworkDriver):
             try:
                 # Try sending ASCII null byte to maintain the connection alive
                 self.device.write_channel(null)
-                return {
-                    "is_alive": self.device.remote_conn.transport.is_active()
-                }
+                return {"is_alive": self.device.remote_conn.transport.is_active()}
             except (socket.error, EOFError):
                 # If unable to send, we can tell for sure that the connection
                 # is unusable
@@ -136,7 +127,7 @@ class NokiaOltDriver(NetworkDriver):
                     line = line.replace(">", " ").replace("<", " ").replace("name=", "")
                     line = line.split()
                     software = f"{line[-2]}"
-                    return {'ISAM': software}
+                    return {"ISAM": software}
 
     def convert_xml_to_list(self, xml_data):
         """Convert xml data to list format"""
@@ -152,7 +143,7 @@ class NokiaOltDriver(NetworkDriver):
             for instance_elem in root.findall("instance"):
                 data = {}
                 for element in instance_elem:
-                    name = element.attrib['name']
+                    name = element.attrib["name"]
                     value = element.text
                     data[name] = value
                 instances.append(data)
@@ -161,7 +152,7 @@ class NokiaOltDriver(NetworkDriver):
             return
 
     def _convert_xml_elem_to_dict(self, elem=None):
-        """convert xml output to dict """
+        """convert xml output to dict"""
         data = {}
         for e in elem.iter():
             if "instance" == e.tag:
@@ -203,11 +194,7 @@ class NokiaOltDriver(NetworkDriver):
     def get_config(self, retrieve="all", full=False, sanitized=False):
         """Returns running config"""
 
-        configs = {
-            "running": "",
-            "startup": "No Startup",
-            "candidate": "No Candidate"
-        }
+        configs = {"running": "", "startup": "No Startup", "candidate": "No Candidate"}
 
         if retrieve in ("all", "running"):
             command = "info configure"
@@ -226,7 +213,7 @@ class NokiaOltDriver(NetworkDriver):
         return configs
 
     def make_device_model(self, data):
-        """get device model, by parsing the "admin display-config' cmd output """
+        """get device model, by parsing the "admin display-config' cmd output"""
 
         if data:
             lines = data.splitlines()
@@ -250,7 +237,7 @@ class NokiaOltDriver(NetworkDriver):
         uptime_output = self._send_command(uptime_command)
         sn_output = self._send_command(sn_command, xml_format=True)
         port_output = self._send_command(port_command, xml_format=True)
-        model_output = self._send_command(model_command,xml_format=False)
+        model_output = self._send_command(model_command, xml_format=False)
         device_model = self.make_device_model(model_output)
 
         hostname_xml_tree = ET.fromstring(hostname_output)
@@ -318,10 +305,7 @@ class NokiaOltDriver(NetworkDriver):
         vlan_name_command = "show vlan name"
         tagging_command = "show vlan residential-bridge extensive"
 
-        vlan_name_output = self._send_command(
-            vlan_name_command,
-            xml_format=True
-        )
+        vlan_name_output = self._send_command(vlan_name_command, xml_format=True)
         tagging_output = self._send_command(tagging_command, xml_format=True)
 
         output_xml_tree = ET.fromstring(vlan_name_output)
@@ -431,7 +415,7 @@ class NokiaOltDriver(NetworkDriver):
         command = "show equipment ont status pon"
         data = self._send_command(command, xml_format=True)
         if data:
-            data_list =  self.convert_xml_to_list(data)
+            data_list = self.convert_xml_to_list(data)
             return self._convert_list_to_dict(data_list, "ont")
         else:
             return f"No available data from the {self.hostname}"
@@ -551,7 +535,7 @@ class NokiaOltDriver(NetworkDriver):
         command = "show vlan fdb-board"
         data = self._send_command(command, xml_format=True)
         if data:
-            data_list =  self.convert_xml_to_list(data)
+            data_list = self.convert_xml_to_list(data)
             return self._convert_list_to_dict(data_list, "mac")
         else:
             return f"No available ** {command} ** data from the {self.hostname}"
@@ -577,7 +561,7 @@ class NokiaOltDriver(NetworkDriver):
             return f"No available ** {command} ** data from the {self.hostname}"
 
     def get_software_mgmt_version_etsi(self):
-        """Returns software version for management """
+        """Returns software version for management"""
         command = "show software-mngt version etsi"
         data = self._send_command(command, xml_format=True)
         if data:
@@ -600,7 +584,7 @@ class NokiaOltDriver(NetworkDriver):
         command = "show equipment diagnostics sfp"
         data = self._send_command(command, xml_format=True)
         if data:
-            data_list =  self.convert_xml_to_list(data)
+            data_list = self.convert_xml_to_list(data)
             return self._convert_list_to_dict(data_list, "position")
         else:
             return f"No available ** {command} ** data from the {self.hostname}"
@@ -625,9 +609,9 @@ class NokiaOltDriver(NetworkDriver):
             new_dict = {}
 
             for entry in loaded_data:
-                port_ = entry['port']
-                vlan_id_ = entry['vlan-id']
-                mac_ = entry['mac']
+                port_ = entry["port"]
+                vlan_id_ = entry["vlan-id"]
+                mac_ = entry["mac"]
 
                 if port_ in new_dict.keys():
                     tmp_data = new_dict[port_]
@@ -661,7 +645,7 @@ class NokiaOltDriver(NetworkDriver):
         ntp_servers = defaultdict(list)
         for sub in data:
             for key in sub:
-                if key == 'server-ip-addrv6':
+                if key == "server-ip-addrv6":
                     ntp_servers[key].append(sub[key])
         return dict(ntp_servers)
 
@@ -747,9 +731,11 @@ class NokiaOltDriver(NetworkDriver):
             if remote_host:
                 lldp[port] = [{"hostname": remote_host.group(1), "port": ""}]
                 try:
-                    remote_port_data = re.search(REMOTE_PORT_REGEX, lldp_data, re.MULTILINE)
+                    remote_port_data = re.search(
+                        REMOTE_PORT_REGEX, lldp_data, re.MULTILINE
+                    )
                     remote_port = remote_port_data.group(1).split()[1]
-                    lldp[port][0]["port"] = remote_port.replace('"','')
+                    lldp[port][0]["port"] = remote_port.replace('"', "")
                 except IndexError:
                     continue
         return lldp
@@ -772,31 +758,52 @@ class NokiaOltDriver(NetworkDriver):
             remote_host = re.findall(REMOTE_HOST_REGEX, lldp_data, re.MULTILINE)
             if len(remote_host) > 0:
                 lldp[port] = [
-                    {"parent_interface": port,
-                     "remote_chassis_id": "",
-                     "remote_system_name": remote_host[0],
-                     "remote_port": "",
-                     "remote_port_description": "",
-                     "remote_system_description": "",
-                     "remote_system_capab": "",
-                     "remote_system_enable_capab": "",
-                     }
+                    {
+                        "parent_interface": port,
+                        "remote_chassis_id": "",
+                        "remote_system_name": remote_host[0],
+                        "remote_port": "",
+                        "remote_port_description": "",
+                        "remote_system_description": "",
+                        "remote_system_capab": "",
+                        "remote_system_enable_capab": "",
+                    }
                 ]
-                remote_chassis_id_data =  re.search(REMOTE_CHASSIS_REGEX, lldp_data, re.MULTILINE)
-                remote_port_descr_data =  re.search(REMOTE_PORT_DESCR_REGEX, lldp_data, re.MULTILINE)
-                remote_sys_descr_data = re.search(REMOTE_SYS_DESCR_REGEX, lldp_data, flags = re.S | re.M)
-                remote_sys_cap_data = re.search(REMOTE_SYS_CAP_REGEX, lldp_data, re.MULTILINE)
-                remote_sys_en_cap_data = re.search(REMOTE_SYS_EN_CAP_REGEX, lldp_data, re.MULTILINE)
+                remote_chassis_id_data = re.search(
+                    REMOTE_CHASSIS_REGEX, lldp_data, re.MULTILINE
+                )
+                remote_port_descr_data = re.search(
+                    REMOTE_PORT_DESCR_REGEX, lldp_data, re.MULTILINE
+                )
+                remote_sys_descr_data = re.search(
+                    REMOTE_SYS_DESCR_REGEX, lldp_data, flags=re.S | re.M
+                )
+                remote_sys_cap_data = re.search(
+                    REMOTE_SYS_CAP_REGEX, lldp_data, re.MULTILINE
+                )
+                remote_sys_en_cap_data = re.search(
+                    REMOTE_SYS_EN_CAP_REGEX, lldp_data, re.MULTILINE
+                )
                 lldp[port][0]["remote_chassis_id"] = remote_chassis_id_data.group(1)
-                lldp[port][0]["remote_port_description"] = remote_port_descr_data.group(1)
-                lldp[port][0]["remote_system_description"] = remote_sys_descr_data.group(1)
-                lldp[port][0]["remote_system_description"] = ' '.join(lldp[port][0]["remote_system_description"].split())
+                lldp[port][0]["remote_port_description"] = remote_port_descr_data.group(
+                    1
+                )
+                lldp[port][0][
+                    "remote_system_description"
+                ] = remote_sys_descr_data.group(1)
+                lldp[port][0]["remote_system_description"] = " ".join(
+                    lldp[port][0]["remote_system_description"].split()
+                )
                 lldp[port][0]["remote_system_capab"] = remote_sys_cap_data.group(1)
-                lldp[port][0]["remote_system_enable_capab"] = remote_sys_en_cap_data.group(1)
+                lldp[port][0][
+                    "remote_system_enable_capab"
+                ] = remote_sys_en_cap_data.group(1)
                 try:
-                    remote_port_data = re.search(REMOTE_PORT_REGEX, lldp_data, re.MULTILINE)
+                    remote_port_data = re.search(
+                        REMOTE_PORT_REGEX, lldp_data, re.MULTILINE
+                    )
                     remote_port = remote_port_data.group(1).split()[1]
-                    lldp[port][0]["remote_port"] = remote_port.replace('"','')
+                    lldp[port][0]["remote_port"] = remote_port.replace('"', "")
                 except IndexError:
                     continue
         return lldp

--- a/napalm_nokia_olt/setup.py
+++ b/napalm_nokia_olt/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="napalm_nokia_olt",
-    version="0.0.48",
+    version="0.0.49",
     author="Dave Macias",
     author_email = "davama@gmail.com",
     description=("Network Automation and Programmability Abstraction "


### PR DESCRIPTION
Bugfixes:
- Always return dict not list
- Fix LLDP remote port for HP Procurve switch neighbors
- Fix typo in method name get_software_mgmt_version_etsi

Improvements:
- Use global variables for regex
- Run Black for linting code

New features: